### PR TITLE
Suporte ao provedor SMTP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,9 +34,22 @@ JWT_EXPIRATION_TIME=3600
 # Encryption key for API keys
 ENCRYPTION_KEY="your-encryption-key"
 
+# Email provider settings
+EMAIL_PROVIDER="sendgrid"
+
 # SendGrid
 SENDGRID_API_KEY="your-sendgrid-api-key"
 EMAIL_FROM="noreply@yourdomain.com"
+
+# SMTP settings
+SMTP_HOST="your-smtp-host"
+SMTP_FROM="noreply-smtp@yourdomain.com"
+SMTP_USER="your-smtp-username"
+SMTP_PASSWORD="your-smtp-password"
+SMTP_PORT=587
+SMTP_USE_TLS=true
+SMTP_USE_SSL=false
+
 APP_URL="https://yourdomain.com"
 
 LANGFUSE_PUBLIC_KEY="your-langfuse-public-key"

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -81,9 +81,22 @@ class Settings(BaseSettings):
     # Encryption settings
     ENCRYPTION_KEY: str = os.getenv("ENCRYPTION_KEY", secrets.token_urlsafe(32))
 
+    # Email provider settings
+    EMAIL_PROVIDER: str = os.getenv("EMAIL_PROVIDER", "sendgrid")
+    
     # SendGrid settings
     SENDGRID_API_KEY: str = os.getenv("SENDGRID_API_KEY", "")
     EMAIL_FROM: str = os.getenv("EMAIL_FROM", "noreply@yourdomain.com")
+    
+    # SMTP settings
+    SMTP_HOST: str = os.getenv("SMTP_HOST", "")
+    SMTP_PORT: int = int(os.getenv("SMTP_PORT", 587))
+    SMTP_USER: str = os.getenv("SMTP_USER", "")
+    SMTP_PASSWORD: str = os.getenv("SMTP_PASSWORD", "")
+    SMTP_USE_TLS: bool = os.getenv("SMTP_USE_TLS", "true").lower() == "true"
+    SMTP_USE_SSL: bool = os.getenv("SMTP_USE_SSL", "false").lower() == "true"
+    SMTP_FROM: str = os.getenv("SMTP_FROM", "")
+    
     APP_URL: str = os.getenv("APP_URL", "http://localhost:8000")
 
     # Server settings


### PR DESCRIPTION
Adiciona suporte ao envio de e-mails via protocolo SMTP, além do já existente provedor SendGrid. Agora é possível selecionar entre **sendgrid** ou **smtp** por meio da variável `EMAIL_PROVIDER`.

Novas variáveis de ambiente:
• `EMAIL_PROVIDER="smtp"` # ou sendgrid
• `SMTP_FROM="noreply-smtp@yourdomain.com"`
• `SMTP_USER="your-smtp-username"`
• `SMTP_PASSWORD="your-smtp-password"`
• `SMTP_HOST="your-smtp-host"`
• `SMTP_PORT=587`
• `SMTP_USE_TLS=true`
• `SMTP_USE_SSL=false`

Testes realizados:
✓ Envio via SendGrid;
✓ Envio via SMTP com TLS;
✓ Envio via SMTP com SSL.