### PR TITLE
chore(workflows): update Docker Hub image name in Docker image workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,7 +10,7 @@ env:
   GHCR_REGISTRY: ghcr.io
   DOCKERHUB_REGISTRY: docker.io
   IMAGE_NAME: ${{ github.repository }}
-  DOCKERHUB_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
+  DOCKERHUB_IMAGE: evoapicloud/evo-ai
 
 jobs:
   build-and-push:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Use hard-coded evoapicloud/evo-ai as the Docker Hub image in the build workflow