### PR TITLE
Update docker-compose.yml image to correct image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   api:
-    image: evo-ai-api:latest
+    image: evoapicloud/evo-ai:latest
     depends_on:
       - postgres
       - redis


### PR DESCRIPTION
Updating image to correct image https://hub.docker.com/r/evoapicloud/evo-ai/tags on latest

## Summary by Sourcery

Bug Fixes:
- Correct the docker-compose API service image to use evoapicloud/evo-ai:latest instead of the local image tag.