### PR TITLE
feat(mcp): enhance MCP server creation with tool discovery and async handling

### DIFF
--- a/src/api/mcp_server_routes.py
+++ b/src/api/mcp_server_routes.py
@@ -28,6 +28,7 @@
 """
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from starlette.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 from src.config.database import get_db
 from typing import List
@@ -54,7 +55,7 @@ router = APIRouter(
     responses={404: {"description": "Not found"}},
 )
 
-
+# Last edited by Arley Peter on 2025-05-17
 @router.post("/", response_model=MCPServer, status_code=status.HTTP_201_CREATED)
 async def create_mcp_server(
     server: MCPServerCreate,
@@ -64,7 +65,7 @@ async def create_mcp_server(
     # Only administrators can create MCP servers
     await verify_admin(payload)
 
-    return mcp_server_service.create_mcp_server(db, server)
+    return await run_in_threadpool(mcp_server_service.create_mcp_server, db, server)
 
 
 @router.get("/", response_model=List[MCPServer])

--- a/src/schemas/schemas.py
+++ b/src/schemas/schemas.py
@@ -262,14 +262,14 @@ class ToolConfig(BaseModel):
     inputModes: List[str] = Field(default_factory=list)
     outputModes: List[str] = Field(default_factory=list)
 
-
+# Last edited by Arley Peter on 2025-05-17
 class MCPServerBase(BaseModel):
     name: str
     description: Optional[str] = None
     config_type: str = Field(default="studio")
     config_json: Dict[str, Any] = Field(default_factory=dict)
     environments: Dict[str, Any] = Field(default_factory=dict)
-    tools: List[ToolConfig] = Field(default_factory=list)
+    tools: Optional[List[ToolConfig]] = Field(default_factory=list) 
     type: str = Field(default="official")
 
 

--- a/src/utils/mcp_discovery.py
+++ b/src/utils/mcp_discovery.py
@@ -1,0 +1,55 @@
+"""
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ @author: Arley Peter                                                         │
+│ @file: mcp_discovery.py                                                      │
+│ Developed by: Arley Peter                                                    │
+│ Creation date: May 05, 2025                                                  │
+├──────────────────────────────────────────────────────────────────────────────┤
+│ @copyright © Evolution API 2025. All rights reserved.                        │
+│ Licensed under the Apache License, Version 2.0                               │
+│                                                                              │
+│ You may not use this file except in compliance with the License.             │
+│ You may obtain a copy of the License at                                      │
+│                                                                              │
+│    http://www.apache.org/licenses/LICENSE-2.0                                │
+│                                                                              │
+│ Unless required by applicable law or agreed to in writing, software          │
+│ distributed under the License is distributed on an "AS IS" BASIS,            │
+│ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.     │
+│ See the License for the specific language governing permissions and          │
+│ limitations under the License.                                               │
+├──────────────────────────────────────────────────────────────────────────────┤
+│ @important                                                                   │
+│ For any future changes to the code in this file, it is recommended to        │
+│ include, together with the modification, the information of the developer    │
+│ who changed it and the date of modification.                                 │
+└──────────────────────────────────────────────────────────────────────────────┘
+"""
+
+from typing import List, Dict, Any
+import asyncio
+
+async def _discover_async(config_json: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Return a list[dict] with the tool metadata advertised by the MCP server."""
+
+    from src.services.mcp_service import MCPService
+
+    service = MCPService()
+    tools, exit_stack = await service._connect_to_mcp_server(config_json)
+    serialised = [t.to_dict() if hasattr(t, "to_dict") else {
+        "id": t.name,
+        "name": t.name,
+        "description": getattr(t, "description", t.name),
+        "tags": getattr(t, "tags", []),
+        "examples": getattr(t, "examples", []),
+        "inputModes": getattr(t, "input_modes", ["text"]),
+        "outputModes": getattr(t, "output_modes", ["text"]),
+    } for t in tools]
+    if exit_stack:
+        await exit_stack.aclose()
+    return serialised
+
+
+def discover_mcp_tools(config_json: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Sync wrapper so we can call it from a sync service function."""
+    return asyncio.run(_discover_async(config_json))


### PR DESCRIPTION
- Implement async MCP server tool discovery
- Add sync wrapper for tool discovery
- Include tool metadata serialization
- Only happens when tool field is empty

## Summary by Sourcery

Enhance MCP server creation by integrating dynamic tool discovery: add an async discovery module with sync wrapper, auto-populate and serialize tools when not provided, adapt the API route to use a threadpool for async handling, and update the schema to accept optional tools.

New Features:
- Introduce asynchronous MCP server tool discovery utility with a synchronous wrapper

Enhancements:
- Auto-populate MCP server tools via discovery when none are provided
- Run the synchronous server creation in a threadpool to support the async API endpoint
- Make the `tools` field optional in the MCP server schema
- Serialize discovered tool metadata for JSON compatibility