### PR TITLE
fix: update import to new path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,15 @@ version: "3.8"
 
 services:
   api:
-    image: evoapicloud/evo-ai:latest
+  # image: evoapicloud/evo-ai:latest Use this image to pull from the repo
+    image: evoai-api:latest # Use this image for local builds
     depends_on:
       - postgres
       - redis
     ports:
       - "8000:8000"
+    env_file:
+      - .env
     environment:
       POSTGRES_CONNECTION_STRING: postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@postgres:5432/evo_ai
       REDIS_HOST: redis

--- a/src/utils/mcp_discovery.py
+++ b/src/utils/mcp_discovery.py
@@ -31,8 +31,7 @@ import asyncio
 
 async def _discover_async(config_json: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Return a list[dict] with the tool metadata advertised by the MCP server."""
-
-    from src.services.mcp_service import MCPService
+    from src.services.adk.mcp_service import MCPService
 
     service = MCPService()
     tools, exit_stack = await service._connect_to_mcp_server(config_json)


### PR DESCRIPTION
- Fixing error when adding new mcp tools
- Adding more information on docker-compose for images
- Adding local .env to docker-compose

## Summary by Sourcery

Update MCPService import path and enhance docker-compose configuration

Bug Fixes:
- Correct MCPService import to use the new adk submodule path

Deployment:
- Enhance docker-compose.yml to comment original image, switch to a local build image, and include a .env file for environment variables