### PR TITLE
fix(chat): scroll da lista de conversas não funciona (SessionList sem h-full)

### DIFF
--- a/frontend/app/chat/components/SessionList.tsx
+++ b/frontend/app/chat/components/SessionList.tsx
@@ -111,7 +111,7 @@ export function SessionList({
   };
 
   return (
-    <div className="w-64 border-r border-neutral-700 flex flex-col bg-neutral-900">
+    <div className="w-64 border-r border-neutral-700 flex flex-col bg-neutral-900 h-full">
       <div className="p-4 border-b border-neutral-700">
         <div className="flex items-center justify-between mb-4">
           <Button


### PR DESCRIPTION
## Problema

Na página `/conversations`, a lista lateral de conversas fica cortada — o usuário não consegue rolar até a última conversa mesmo com 100+ itens carregados.

## Root cause

`SessionList.tsx` — o container raiz (`<div className="w-64 ...">`) não tinha `h-full`. Sem uma altura limitada, o filho `<div className="flex-1 overflow-y-auto">` crescia infinitamente com o conteúdo e o `overflow-y: auto` nunca ativava. O scroll terminava caindo no `<main class="overflow-auto">` do `client-layout.tsx`, rolando a página inteira em vez de rolar só a lista.

## Fix

```tsx
// ANTES
<div className="w-64 border-r border-neutral-700 flex flex-col bg-neutral-900">

// DEPOIS
<div className="w-64 border-r border-neutral-700 flex flex-col bg-neutral-900 h-full">
```

**Mudança:** 1 classe CSS (`h-full`) adicionada na linha 114 de `SessionList.tsx`.

## Como testar

1. Abrir `/conversations` com 50+ conversas carregadas
2. Verificar que a lista lateral scrolla independentemente do restante da página
3. Navegar até a última conversa sem problema

## Summary by Sourcery

Bug Fixes:
- Fix the conversations sidebar so the session list can scroll independently and fully within the `/conversations` page.